### PR TITLE
Update plan_of_action.md with Phase 1 Migration Targets

### DIFF
--- a/plan_of_action.md
+++ b/plan_of_action.md
@@ -9,6 +9,12 @@ This phase focuses on building the foundational simulation logic in Rust.
 
 * **Data Modeling**: Define the core simulation data structures, such as `City`, `Tile`, and `ZoneData`, within a new Rust library crate.
 * **Logic Porting**: Systematically port the existing C simulation logic from files like `s_sim.c`, `s_zone.c`, `s_scan.c`, and `s_traf.c` into idiomatic Rust functions or systems.
+    *   **Migration Targets**:
+        *   `micropolis-activity/src/sim/s_sim.c`: Contains the main simulation loop and coordination logic.
+        *   `micropolis-activity/src/sim/s_zone.c`: Handles logic related to zone development (residential, commercial, industrial).
+        *   `micropolis-activity/src/sim/s_scan.c`: Contains scanning functions that iterate over the city map.
+        *   `micropolis-activity/src/sim/s_traf.c`: Manages the traffic simulation logic.
+        *   `micropolis-activity/src/sim/s_eval.c`: Contains city evaluation logic.
     *   **Completed**:
         *   Ported `DoHospChur` and `RepairZone` from `s_zone.c` to `zone.rs`.
         *   Ported `GetAssValue` and `DoPopNum` from `s_eval.c` to `sim.rs`.


### PR DESCRIPTION
This change updates the `plan_of_action.md` file to include a detailed enumeration of the C files that need to be ported to Rust for Phase 1 of the project. The following files have been identified as migration targets:

*   `micropolis-activity/src/sim/s_sim.c`
*   `micropolis-activity/src/sim/s_zone.c`
*   `micropolis-activity/src/sim/s_scan.c`
*   `micropolis-activity/src/sim/s_traf.c`
*   `micropolis-activity/src/sim/s_eval.c`

This addresses the user's request to add more detail to the migration plan.

---
*PR created automatically by Jules for task [9641940578218637138](https://jules.google.com/task/9641940578218637138) started by @IgnatiusPang*